### PR TITLE
🐞 fix(修改了apps下面的frps的scripts): 解决frps使用tcp时的端口权限

### DIFF
--- a/apps/frps/scripts/config.sh
+++ b/apps/frps/scripts/config.sh
@@ -18,6 +18,7 @@ if [ "$enable" == '1' ]; then
 		readsh "请输入${appname}的kcp配置[1/0]" "kcp" "1"
 		readsh "请输入${appname}用于http穿透的端口号" "http_port" "90"
 		readsh "请输入${appname}用于https穿透的端口号" "https_port" "91"
+		readsh "请输入${appname}用于tcp的端口号" "allow_tcp_ports" "10001-11000"
 		readsh "请输入${appname}访问密钥" "token" "12345678"
 		readsh "请输入${appname}子域名" "subdomain" 
 		read -p "是否启用${appname}的web控制面板？[1/0] " res

--- a/apps/frps/scripts/frps.sh
+++ b/apps/frps/scripts/frps.sh
@@ -9,6 +9,7 @@ open_ports() {
     [ -n "$http_port" ] && open_port $http_port
     [ -n "$https_port" ] && open_port $https_port
     [ -n "$dashboard_port" ] && open_port $dashboard_port
+    [ -n "$allow_tcp_ports" ] && open_port ${allow_tcp_ports//-/:}
 }
 
 start() {
@@ -39,6 +40,7 @@ token = $token
 #max_ports_per_client = 0
 #authentication_timeout = 900
 `[ -n "$subdomain" ] && echo "subdomain_host = $subdomain"`
+`[ -n "$allow_tcp_ports" ] && echo "allow_ports = $allow_tcp_ports"`
 tcp_mux = true
 EOF
 	daemon ${mbroot}/apps/${appname}/bin/${appname} -c ${mbroot}/apps/${appname}/config/${appname}.conf


### PR DESCRIPTION
修改原因：
1. tcp转发是需要登录路由手动执行iptables添加tcp转发的端口才能正常使用
2. 限制frps使用的端口范围，避免端口滥用

修改内容：
1. 在config.sh添加允许tcp端口范围的配置，以避免端口滥用。（填写示例：10001,1005 或 10002-10100, 20001 或 1002-1010, 2020-2021等）
2. 配置frps.sh及时调用open_port函数开启对应端口，确保tcp的frp转发正常运作

之前的版本因为没有配置tcp的转发的iptables导致tcp不能正常转发，需要登陆路由器手动添加的问题：https://github.com/fatedier/frp/issues/2407